### PR TITLE
Feature/add author

### DIFF
--- a/class.dable.php
+++ b/class.dable.php
@@ -56,7 +56,7 @@ class Dable
 
 		$meta = array(
 			'dable:item_id' => $post->ID,
-			'article:published_time' => get_the_date( 'c', $post ),
+			'dable:published_time' => get_post_time( 'c', false, $post, false ),
 			'dable:author' => get_the_author_meta( 'display_name', $post->post_author ),
 		);
 
@@ -70,6 +70,8 @@ class Dable
 			$meta['og:url'] = get_permalink( $post );
 			$meta['og:title'] = get_the_title( $post );
 			$meta['og:description'] = get_the_excerpt( $post );
+			$meta['article:published_time'] = $meta['dable:published_time'];
+			// TODO : change option variable's name to embrace article:published_time
 		} else {
 			unset( $meta['og:image'] );
 		}

--- a/class.dable.php
+++ b/class.dable.php
@@ -57,6 +57,7 @@ class Dable
 		$meta = array(
 			'dable:item_id' => $post->ID,
 			'article:published_time' => get_the_date( 'c', $post ),
+			'dable:author' => get_the_author_meta( 'display_name', $post->post_author ),
 		);
 
 		$thumbnail = $this->get_thumbnail( $post );

--- a/dable-for-wordpress.php
+++ b/dable-for-wordpress.php
@@ -4,16 +4,16 @@ Plugin Name: Dable for WordPress
 Description: Add Dable widgets and meta tags.
 Author: Dable
 Text Domain: dable
-Version: 3.0.3
+Version: 3.1.0
 Author URI: http://dable.io
 Domain Path: /languages
 */
 /**
  * @package dable
- * @version 3.0.3
+ * @version 3.1.0
  */
 
-define( 'DABLE_PLUGIN_VERSION', '3.0.3' );
+define( 'DABLE_PLUGIN_VERSION', '3.1.0' );
 define( 'DABLE_PLUGIN_BASENAME', plugin_basename(__FILE__) );
 define( 'DABLE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define( 'DABLE_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/readme.txt
+++ b/readme.txt
@@ -78,9 +78,13 @@ No notice
 * Resize thumbnails
 
 = 3.0.2 =
-* Revised settings panel design
+* Revise settings panel design
 * Show Dable news in plugin settings page
-* Added i18n support
+* Add i18n support
 
 = 3.0.3 =
 * Polished translations
+
+= 3.1.0 =
+* Add dable:author meta tag
+* Change article:published_time to dable:published_time


### PR DESCRIPTION
작성자명 메타태그 추가
발행시각 메타태그를 dable:published_time 으로 변경
  - get_the_date 함수를 override 하여 표시되는 timestamp format을 변경하는 경우가 있어 한단계 더 낮은 레벨에서 timestamp를 찾아오도록 수정