### PR TITLE
remove service name setting UI

### DIFF
--- a/class.dable.php
+++ b/class.dable.php
@@ -117,7 +117,7 @@ class Dable
 	<script>
 	(function(d,a,b,l,e,_) { d[b]=d[b]||function(){(d[b].q=d[b].q||[]).push(arguments)};e=a.createElement(l);e.async=1;e.charset='utf-8';e.src='//static.dable.io/dist/plugin.min.js';_=a.getElementsByTagName(l)[0];_.parentNode.insertBefore(e,_);})(window,document,'dable','script');
 	dable('setService', '<?php echo $service_name ?>');
-	dable('sendLog');
+	dable('sendLogOnce');
 	</script>
 	<!-- <?php echo __('End Dable Script / For inquiries, support@dable.io'); ?> -->
 <?php

--- a/dable-for-wordpress.php
+++ b/dable-for-wordpress.php
@@ -4,16 +4,16 @@ Plugin Name: Dable for WordPress
 Description: Add Dable widgets and meta tags.
 Author: Dable
 Text Domain: dable
-Version: 3.1.0
+Version: 3.2.0
 Author URI: http://dable.io
 Domain Path: /languages
 */
 /**
  * @package dable
- * @version 3.1.0
+ * @version 3.2.0
  */
 
-define( 'DABLE_PLUGIN_VERSION', '3.1.0' );
+define( 'DABLE_PLUGIN_VERSION', '3.2.0' );
 define( 'DABLE_PLUGIN_BASENAME', plugin_basename(__FILE__) );
 define( 'DABLE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define( 'DABLE_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/views/settings.php
+++ b/views/settings.php
@@ -8,24 +8,6 @@
 		<section>
 			<h2><?php esc_html_e('Default Settings', 'dable'); ?></h2>
 			<p><?php esc_html_e('Please enter the required default settings', 'dable'); ?></p>
-			<h3>
-				<?php esc_html_e('Service Name', 'dable'); ?>
-				<button type="button" class="toggle"><span class="dashicons dashicons-editor-help"></span></button>
-			</h3>
-			<p class="desc">
-				<?php esc_html_e('For personalized content recommendation, the log collection script should be inserted in your site. By entering the service name provided via e-mail, the log collection script will be automatically inserted.', 'dable'); ?>
-			</p>
-			<p>
-				<span class="dable-input-tag">
-					<label for="service_name_desktop" class="dable-input-tag__tag"><?php esc_html_e( 'Desktop' ); ?></label>
-					<input type="text" id="service_name_desktop" name="dable-settings[service_name]" class="regular-text dable-input-tag__input" value="<?php echo esc_attr( $this->get_option( 'service_name', '' ) ); ?>">
-				</span>
-				<span class="dable-input-tag">
-					<label for="service_name_mobile" class="dable-input-tag__tag"><?php esc_html_e( 'Mobile' ); ?></label>
-					<input type="text" id="service_name_mobile" name="dable-settings[service_name_mobile]" class="regular-text dable-input-tag__input" value="<?php echo esc_attr( $this->get_option( 'service_name_mobile', '' ) ); ?>">
-				</span>
-				<span><?php esc_html_e('Service Name for Dable Script.', 'dable'); ?></span>
-			</p>
 
 			<h3>
 				<?php esc_html_e('Content Wrapper Setting', 'dable'); ?>


### PR DESCRIPTION
 - 위젯 스크립트의 변경(to 통합 위젯 스크립트)으로 로그 전송이 필요없게 되어 로그 전송에 필요한 서비스명 입력 UI를 제거한다.
 - 구 위젯 스크립트 사용자를 위해 이미 저장된 값에 따른 로그 수집 스크립트 삽입은 유지한다.
 - 구 위젯 스크립트 사용자들의 로그 중복 전송을 방지한다.