### PR TITLE
MODIFY: description에 더보기 태그가 붙는 이슈

### DIFF
--- a/class.dable.php
+++ b/class.dable.php
@@ -67,6 +67,9 @@ class Dable
 		}
 
 		if ( ! empty( $this->options['print_og_tag'] ) ) {
+			// Remove read more tag after 55 words
+			add_filter('excerpt_more', '__return_empty_string');
+
 			$meta['og:url'] = get_permalink( $post );
 			$meta['og:title'] = get_the_title( $post );
 			$meta['og:description'] = get_the_excerpt( $post );

--- a/dable-for-wordpress.php
+++ b/dable-for-wordpress.php
@@ -4,16 +4,16 @@ Plugin Name: Dable for WordPress
 Description: Add Dable widgets and meta tags.
 Author: Dable
 Text Domain: dable
-Version: 3.2.3
+Version: 3.2.4
 Author URI: http://dable.io
 Domain Path: /languages
 */
 /**
  * @package dable
- * @version 3.2.3
+ * @version 3.2.4
  */
 
-define( 'DABLE_PLUGIN_VERSION', '3.2.3' );
+define( 'DABLE_PLUGIN_VERSION', '3.2.4' );
 define( 'DABLE_PLUGIN_BASENAME', plugin_basename(__FILE__) );
 define( 'DABLE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define( 'DABLE_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://dable.io/
 Tags: dable
 Requires at least: 4.6
 Tested up to: 5.4
-Stable tag: 3.2.3
+Stable tag: 3.2.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,3 +101,6 @@ No notice
 
 = 3.2.3 =
 * Fix bug of Open Graph Meta Tags feature
+
+= 3.2.4 =
+* Remove read-more tag from og:description


### PR DESCRIPTION
# Do
- `og:description`을 생성할 때, 본문의 [excerpt](https://wordpress.org/support/article/excerpt/)가 적용된다
- excerpt가 작성되지 않은 경우, 본문의 단어 55개가 적용되고 
   단어가 55개 이상인 경우, read more 태그가 붙고 있다.
- 이슈를 해결하기 위해 [empty string 필터](https://developer.wordpress.org/reference/functions/__return_empty_string/)를 추가한다

  - AS IS:
  ![스크린샷 2021-01-18 오후 4 08 25](https://user-images.githubusercontent.com/52514466/104883137-9dfdd280-59a7-11eb-9db5-22c2d658abf7.png)
  - TO BE:
  ![스크린샷 2021-01-18 오후 4 11 39](https://user-images.githubusercontent.com/52514466/104883264-dac9c980-59a7-11eb-8bfe-76a3549d94f6.png)
