### PR TITLE
MODIFY: Thumbnail Size 세팅이 변경된 경우 섬네일 다시 생성

### DIFF
--- a/class.dable.php
+++ b/class.dable.php
@@ -140,8 +140,12 @@ class Dable
 			// Does it has dable-og-thumbnail size image?
 			$attach_data = wp_get_attachment_metadata( $image_id, true );
 
+			$og_options = get_option( 'dable-og-settings', array() );
+			$org_thumbnail_size = $og_options['thumbnail_size'];
+			$curr_thumbnail_size = $attach_data['sizes']['dable-og-thumbnail']['width'];
+
 			// If not, create a new thumbnail for og:image.
-			if ( ! is_array($attach_data) || ! isset($attach_data['sizes']['dable-og-thumbnail']) ) {
+			if ( ! is_array($attach_data) || ! isset($attach_data['sizes']['dable-og-thumbnail']) || $org_thumbnail_size !== $curr_thumbnail_size ) {
 				if  ( ! function_exists( 'wp_crop_image' ) ) {
 					require_once ABSPATH . 'wp-admin/includes/image.php';
 				}

--- a/class.dable.php
+++ b/class.dable.php
@@ -139,13 +139,15 @@ class Dable
 		if ( $image_id ) {
 			// Does it has dable-og-thumbnail size image?
 			$attach_data = wp_get_attachment_metadata( $image_id, true );
-
 			$og_options = get_option( 'dable-og-settings', array() );
-			$org_thumbnail_size = $og_options['thumbnail_size'];
-			$curr_thumbnail_size = $attach_data['sizes']['dable-og-thumbnail']['width'];
+
+			$curr_thumbnail_setting = $og_options['thumbnail_size'];
+			$org_width = is_array($attach_data) ? $attach_data['sizes']['dable-og-thumbnail']['width'] : null;
+			$org_height = is_array($attach_data) ? $attach_data['sizes']['dable-og-thumbnail']['height'] : null;
+			$is_thumbnail_setting_updated = $curr_thumbnail_setting !== $org_width && $curr_thumbnail_setting !== $org_height;
 
 			// If not, create a new thumbnail for og:image.
-			if ( ! is_array($attach_data) || ! isset($attach_data['sizes']['dable-og-thumbnail']) || $org_thumbnail_size !== $curr_thumbnail_size ) {
+			if ( ! is_array($attach_data) || ! isset($attach_data['sizes']['dable-og-thumbnail']) || $is_thumbnail_setting_updated ) {
 				if  ( ! function_exists( 'wp_crop_image' ) ) {
 					require_once ABSPATH . 'wp-admin/includes/image.php';
 				}

--- a/dable-for-wordpress.php
+++ b/dable-for-wordpress.php
@@ -4,16 +4,16 @@ Plugin Name: Dable for WordPress
 Description: Add Dable widgets and meta tags.
 Author: Dable
 Text Domain: dable
-Version: 3.2.4
+Version: 3.2.5
 Author URI: http://dable.io
 Domain Path: /languages
 */
 /**
  * @package dable
- * @version 3.2.4
+ * @version 3.2.5
  */
 
-define( 'DABLE_PLUGIN_VERSION', '3.2.4' );
+define( 'DABLE_PLUGIN_VERSION', '3.2.5' );
 define( 'DABLE_PLUGIN_BASENAME', plugin_basename(__FILE__) );
 define( 'DABLE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define( 'DABLE_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://dable.io/
 Tags: dable
 Requires at least: 4.6
 Tested up to: 5.4
-Stable tag: 3.2.4
+Stable tag: 3.2.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -104,3 +104,6 @@ No notice
 
 = 3.2.4 =
 * Remove read-more tag from og:description
+
+= 3.2.5 =
+* Resize thumbnail if Thumbnail Size setting is updated


### PR DESCRIPTION
## Do
- 워드프레스 플러그인에서 Thumbnail Size 세팅을 변경한 경우 이미 생성된 이미지가 있더라도 신규 세팅 기준으로 다시 생성하도록 함
- Thumbnail Size 세팅 변경여부 확인 로직
  - 섬네일 세팅값은 width와 height 중 작은 값에 적용된다.
  - 기존 섬네일의 width와 height 모두 현재 섬네일 세팅값과 다른 경우, 섬네일 세팅이 변경되었다고 판단한다.
  - 제공되는 섬네일 세팅값이 250/600이기 때문에 250x600 (or 600x250) 사이즈 섬네일은 위 조건에서 섬네일 변경여부를 체크할 수 없으나 극소수일 것으로 판단해 보수적으로 조건을 정했다.

## Notion
- https://www.notion.so/dableglobal/Widget-Modification-AutoBuzz-5e04bdbfc21645b1b862bbce35813f8f

## Why
- 이미지 블러 이슈로 Thumbnail Size 세팅을 변경했으나, 신규 등록 기사의 섬네일에만 적용되고 기존에 수집된 기사에는 적용되지 않는 이슈
 ![스크린샷 2022-03-11 오후 1 40 59](https://user-images.githubusercontent.com/52514466/157803482-0b9d2071-b3b2-40cc-b8a0-a8a1c47fed90.png)
 