### PR TITLE
[SUPPORT-1446] FIX: 워드프레스 에러메시지 대응

### DIFF
--- a/class.dable-api.php
+++ b/class.dable-api.php
@@ -22,7 +22,10 @@ class DableAPI {
 					'default' => 3,
 					'sanitize_callback' => 'absint'
 				)
-			)
+			),
+			// public api는 __return_true 처리하도록 안내하고 있음
+			// 가이드: https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/
+			'permission_callback' => '__return_true'
 		) );
 	}
 

--- a/class.dable.php
+++ b/class.dable.php
@@ -142,12 +142,13 @@ class Dable
 			$og_options = get_option( 'dable-og-settings', array() );
 
 			$curr_thumbnail_setting = $og_options['thumbnail_size'];
-			$org_width = is_array($attach_data) ? $attach_data['sizes']['dable-og-thumbnail']['width'] : null;
-			$org_height = is_array($attach_data) ? $attach_data['sizes']['dable-og-thumbnail']['height'] : null;
+			$has_thumbnail_setting = is_array($attach_data) && isset($attach_data['sizes']) && isset($attach_data['sizes']['dable-og-thumbnail']);
+			$org_width = $has_thumbnail_setting ? $attach_data['sizes']['dable-og-thumbnail']['width'] : null;
+			$org_height = $has_thumbnail_setting ? $attach_data['sizes']['dable-og-thumbnail']['height'] : null;
 			$is_thumbnail_setting_updated = $curr_thumbnail_setting !== $org_width && $curr_thumbnail_setting !== $org_height;
 
 			// If not, create a new thumbnail for og:image.
-			if ( ! is_array($attach_data) || ! isset($attach_data['sizes']['dable-og-thumbnail']) || $is_thumbnail_setting_updated ) {
+			if ( ! $has_thumbnail_setting || $is_thumbnail_setting_updated ) {
 				if  ( ! function_exists( 'wp_crop_image' ) ) {
 					require_once ABSPATH . 'wp-admin/includes/image.php';
 				}

--- a/dable-for-wordpress.php
+++ b/dable-for-wordpress.php
@@ -4,16 +4,16 @@ Plugin Name: Dable for WordPress
 Description: Add Dable widgets and meta tags.
 Author: Dable
 Text Domain: dable
-Version: 3.2.5
+Version: 3.2.6
 Author URI: http://dable.io
 Domain Path: /languages
 */
 /**
  * @package dable
- * @version 3.2.5
+ * @version 3.2.6
  */
 
-define( 'DABLE_PLUGIN_VERSION', '3.2.5' );
+define( 'DABLE_PLUGIN_VERSION', '3.2.6' );
 define( 'DABLE_PLUGIN_BASENAME', plugin_basename(__FILE__) );
 define( 'DABLE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define( 'DABLE_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://dable.io/
 Tags: dable
 Requires at least: 4.6
 Tested up to: 5.4
-Stable tag: 3.2.5
+Stable tag: 3.2.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -107,3 +107,7 @@ No notice
 
 = 3.2.5 =
 * Resize thumbnail if Thumbnail Size setting is updated
+
+= 3.2.6 =
+* Fix bug of thumbnail update
+* Refactor API Route


### PR DESCRIPTION
## Do
- 섬네일 세팅을 읽을 때 null 케이스 체크
- 라우트 콜백 대응 추가

## Jira
- https://teamdable.atlassian.net/browse/SUPPORT-1446

## Why
- type null & undefined 에러 대응
  ```
  Undefined index: dable-og-thumbnail in /home/794846.cloudwaysapps.com/xhkghxatyx/public_html/wp-content/plugins/dable/class.dable.php on line 151
  Trying to access array offset on value of type null in /home/794846.cloudwaysapps.com/xhkghxatyx/public_html/wp-content/plugins/dable/class.dable.php on line 151
  ```
- callback 에러 대응
  ```
  함수 register_rest_route이(가) 바르지 않게 호출됐습니다. dable/v1/news의 레스트 API 라우트 정의에 요구되는 permission_callback 인자가 없습니다. 공개할 의도가 있는 레스트 API 라우트는 권한 콜백으로 __return_true을(를) 사용합니다. 더 자세한 정보는 [워드프레스 디버깅하기](https://wordpress.org/support/article/debugging-in-wordpress/)를 보세요. (이 메세지는 버전 5.5.0에서 추가되었습니다.)
  ```