### PR TITLE
[SUPPORT-3131] FIX: Target Post Types 설정에 따라 본문 위젯이 동작하도록 수정

### DIFF
--- a/class.dable.php
+++ b/class.dable.php
@@ -180,7 +180,9 @@ class Dable
 	}
 
 	public function add_content_wrapper( $content ) {
-		if ( is_feed() || ! is_singular() ) {
+		// Apply the same eligibility rule as header/meta rendering,
+		// so widgets are only added for the target post types.
+		if ( is_feed() || ! Dable::is_eligible_post_type() ) {
 			return $content;
 		}
 


### PR DESCRIPTION
#### 배경
- https://teamdable.atlassian.net/browse/SUPPORT-3131
- 워드프레스 블로그에서 설정과 달리 위젯이 본문뿐 아니라 메인에도 노출되는 이슈가 발생하였는데, 아래와 같은 원인이 유력해보여 수정해두었습니다.

#### 기존 동작
- add_content_wrapper()가 is_singular()만 사용하여, Target Post Types와 관계없이 모든 단일 포스트 타입(post, page 등) 에 위젯을 삽입함
  - 예: Target Post Types에 Posts만 설정해도, page 타입에서도 본문 아래 데이블 위젯이 노출되는 문제 발생
#### 변경 내용
- add_content_wrapper() 조건을 아래와 같이 변경
  - 변경 전: `if ( is_feed() || ! is_singular() ) { ... }`
  - 변경 후: `if ( is_feed() || ! Dable::is_eligible_post_type() ) { ... }`
- 헤더 메타/스크립트 출력(print_header())과 동일하게, Dable::is_eligible_post_type() 내부에서 Target Post Types(dable-target-post-types) 옵션을 기반으로 is_singular()를 평가하도록 통일
#### 결과
- Target Post Types = post 인 경우
  <img width="892" height="449" alt="스크린샷 2025-12-03 오후 6 38 47" src="https://github.com/user-attachments/assets/22aef06d-f4fd-4c13-811a-c95fb7aea2c1" />
- single post 화면: 본문 위젯 삽입 (기존과 동일)
  <img width="1538" height="1024" alt="스크린샷 2025-12-03 오후 6 38 31" src="https://github.com/user-attachments/assets/8e433d24-9f0f-4789-bdf7-d2b146cf464b" />
- page 타입: 본문 위젯 미삽입 (기존과 달리, 설정과 일치하는 동작)
  <img width="1538" height="1261" alt="스크린샷 2025-12-03 오후 6 38 18" src="https://github.com/user-attachments/assets/69905614-a2d6-43d8-b28f-0cbb0ffdcabd" />
