### PR TITLE
[SUPPORT-3131] FIX: post타입에서만 위젯 표시 안되로록 수정

### DIFF
--- a/class.dable.php
+++ b/class.dable.php
@@ -182,7 +182,7 @@ class Dable
 	public function add_content_wrapper( $content ) {
 		// Apply the same eligibility rule as header/meta rendering,
 		// so widgets are only added for the target post types.
-		if ( is_feed() || ! Dable::is_eligible_post_type() ) {
+		if ( is_feed() || is_home() || is_front_page() || ! Dable::is_eligible_post_type() ) {
 			return $content;
 		}
 

--- a/class.dable.php
+++ b/class.dable.php
@@ -180,9 +180,8 @@ class Dable
 	}
 
 	public function add_content_wrapper( $content ) {
-		// Apply the same eligibility rule as header/meta rendering,
-		// so widgets are only added for the target post types.
-		if ( is_feed() || is_home() || is_front_page() || ! Dable::is_eligible_post_type() ) {
+		// Widgets should only appear on individual post pages, not on pages, home page, or front page.
+		if ( is_feed() || is_home() || is_front_page() || ! is_singular( 'post' ) ) {
 			return $content;
 		}
 

--- a/dable-for-wordpress.php
+++ b/dable-for-wordpress.php
@@ -4,16 +4,16 @@ Plugin Name: Dable for WordPress
 Description: Add Dable widgets and meta tags.
 Author: Dable
 Text Domain: dable
-Version: 3.3.4
+Version: 3.3.5
 Author URI: http://dable.io
 Domain Path: /languages
 */
 /**
  * @package dable
- * @version 3.3.4
+ * @version 3.3.5
  */
 
-define( 'DABLE_PLUGIN_VERSION', '3.3.4' );
+define( 'DABLE_PLUGIN_VERSION', '3.3.5' );
 define( 'DABLE_PLUGIN_BASENAME', plugin_basename(__FILE__) );
 define( 'DABLE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define( 'DABLE_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://dable.io/
 Tags: dable
 Requires at least: 4.6
 Tested up to: 6.2
-Stable tag: 3.3.4
+Stable tag: 3.3.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -128,3 +128,6 @@ No notice
 
 = 3.3.4 =
 * Re-release of version 3.3.3: Content widget now respects Target Post Types setting
+
+= 3.3.5 =
+* Fix: Prevent widgets from appearing on home page and front page


### PR DESCRIPTION
## 문제

- [SUPPORT-3131](https://teamdable.atlassian.net/browse/SUPPORT-3131): 메인 페이지(홈페이지/front page)에서 위젯이 노출되는 이슈
- [WordPress 설정 가이드](https://support.dable.io/wordpress-setting-guide)에 따르면 Target Post Types는 추천 콘텐츠에 포함할 포스트 타입을 선택하는 설정이며, 위젯 삽입 조건과는 무관합니다.
- 위젯은 개별 포스트 페이지에만 표시되어야 하므로, Target Post Types 설정과 무관하게 포스트(`post`) 타입에서만 위젯이 삽입되도록 수정하였습니다.

## 변경 사항

- `add_content_wrapper` 함수의 조건을 `! Dable::is_eligible_post_type()`에서 `! is_singular( 'post' )`로 변경
- 위젯이 포스트 타입에서만 삽입되도록 처리
- 메인 페이지(`is_home() || is_front_page()`)에서도 위젯이 삽입되지 않도록 기존 체크 유지

## 동작 방식

- 포스트 페이지: 위젯 표시 ✅
- 페이지(Page): 위젯 표시 안 함 ❌
- 메인 페이지: 위젯 표시 안 함 ❌
- 피드 페이지: 위젯 표시 안 함 ❌

[SUPPORT-3131]: https://teamdable.atlassian.net/browse/SUPPORT-3131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ